### PR TITLE
Fix SetKeepAlive to 2 minutes instead of 2 milliseconds

### DIFF
--- a/mosquitto/mosquitto.go
+++ b/mosquitto/mosquitto.go
@@ -77,7 +77,7 @@ func StartBroker(data MqttConf) {
 		SetDefaultPublishHandler(messagePubHandler).
 		SetConnectionLostHandler(connectLostHandler).
 		SetOnConnectHandler(connectHandler).
-		SetKeepAlive(keyLifeTime).
+		SetKeepAlive(keyLifeTime*time.Minute).
 		SetWill(data.PubTopic+"online", "false", 2, true)
 
 	conn := mqtt.NewClient(mqttHandler)


### PR DESCRIPTION
2 milliseconds is rounded to zero, which is rejected by some MQTT brokers.